### PR TITLE
allow SO_REUSEADDR

### DIFF
--- a/src/com/t_oster/liblasercut/drivers/ruida/UdpStream.java
+++ b/src/com/t_oster/liblasercut/drivers/ruida/UdpStream.java
@@ -60,6 +60,7 @@ public class UdpStream extends OutputStream
     this.port = port;
     System.out.println("UdpStream(" + hostname + ", " + port + ")");
     socket = new DatagramSocket(SOURCE_PORT);
+    socket.setReuseAddr(true);
     address = InetAddress.getByName(hostname);
     bos = new ByteArrayOutputStream();
   }


### PR DESCRIPTION
Avoid some errors like these:
JOB title >visicut 4< name >visicut 4< user >visicut<
UdpStream(192.168.2.21, 50200)
java.net.BindException: Die Adresse wird bereits verwendet (Bind failed)
	at java.net.PlainDatagramSocketImpl.bind0(Native Method)
	at java.net.AbstractPlainDatagramSocketImpl.bind(AbstractPlainDatagramSocketImpl.java:93)
	at java.net.DatagramSocket.bind(DatagramSocket.java:392)
	at java.net.DatagramSocket.<init>(DatagramSocket.java:242)
	at java.net.DatagramSocket.<init>(DatagramSocket.java:299)
	at java.net.DatagramSocket.<init>(DatagramSocket.java:271)
	at com.t_oster.liblasercut.drivers.ruida.UdpStream.<init>(UdpStream.java:62)
	at com.t_oster.liblasercut.drivers.ruida.Ruida.openNetwork(Ruida.java:114)
	at com.t_oster.liblasercut.drivers.ThunderLaser.sendJob(ThunderLaser.java:551)
	at com.t_oster.visicut.VisicutModel.sendJob(VisicutModel.java:756)
	at com.t_oster.visicut.gui.MainView$64.run(MainView.java:2216)
java.net.BindException: Die Adresse wird bereits verwendet (Bind failed)
	at java.net.PlainDatagramSocketImpl.bind0(Native Method)
	at java.net.AbstractPlainDatagramSocketImpl.bind(AbstractPlainDatagramSocketImpl.java:93)
	at java.net.DatagramSocket.bind(DatagramSocket.java:392)
	at java.net.DatagramSocket.<init>(DatagramSocket.java:242)
	at java.net.DatagramSocket.<init>(DatagramSocket.java:299)
	at java.net.DatagramSocket.<init>(DatagramSocket.java:271)
	at com.t_oster.liblasercut.drivers.ruida.UdpStream.<init>(UdpStream.java:62)
	at com.t_oster.liblasercut.drivers.ruida.Ruida.openNetwork(Ruida.java:114)
	at com.t_oster.liblasercut.drivers.ThunderLaser.sendJob(ThunderLaser.java:551)
	at com.t_oster.visicut.VisicutModel.sendJob(VisicutModel.java:756)
	at com.t_oster.visicut.gui.MainView$64.run(MainView.java:2216)